### PR TITLE
Fixed some issues with WTML file

### DIFF
--- a/content/BUACStellarLifeCycles.wtml
+++ b/content/BUACStellarLifeCycles.wtml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Folder MSRCommunityId="0" MSRComponentId="0" Permission="0" Name="BUAC Stellar Life Cycles" Group="Explorer" Searchable="False" Type="Earth">
   <VersionDependent>false</VersionDependent>
-  <Place MSRCommunityId="0" MSRComponentId="0" Permission="0" Name="Hubble Probes the Great Orion Nebula" DataSetType="Sky" RA="5.5883333333333276" Dec="-5.40555555555556" Constellation="ORI" Classification="Nebula" Magnitude="0" Distance="0" ZoomLevel="3.97833333333333" Rotation="0" Angle="0" DomeAlt="0" DomeAz="0" Opacity="100" AngularSize="3.97833333333333">
+  <!--
+  <Place2 MSRCommunityId="0" MSRComponentId="0" Permission="0" Name="Hubble Probes the Great Orion Nebula" DataSetType="Sky" RA="5.5883333333333276" Dec="-5.40555555555556" Constellation="ORI" Classification="Nebula" Magnitude="0" Distance="0" ZoomLevel="3.97833333333333" Rotation="0" Angle="0" DomeAlt="0" DomeAz="0" Opacity="100" AngularSize="3.97833333333333">
     <Target>orionproplid</Target>
     <ForegroundImageSet>
       <ImageSet DemUrl="" MSRCommunityId="0" MSRComponentId="0" Permission="0" Generic="False" DataSetType="Sky" BandPass="Visible" Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000000302{Q}?g=138" TileLevels="5" WidthFactor="2" Sparse="True" Rotation="75.4310456965389" QuadTreeMap="0123" Projection="Tangent" Name="Hubble Probes the Great Orion Nebula" FileType=".png" CenterY="-5.4055466" CenterX="83.8268692" BottomsUp="False" StockSet="False" ElevationModel="False" OffsetX="0" OffsetY="0" BaseTileLevel="0" BaseDegreesPerTile="0.0813707558539556" MeanRadius="0" FOV="1.6">
@@ -14,6 +15,7 @@
       <p>Hubble sees baby stars</p>
     </Description>
   </Place2>
+
   <Place Name="HOPS 68" RA="5.59008331" Dec="-5.1418572" ZoomLevel="1.10071569519368" DataSetType="Sky" Opacity="100" Constellation="">
     <ForegroundImageSet>
       <ImageSet DataSetType="Sky" BandPass="Visible" Url="http://www.spitzer.caltech.edu/uploaded_files/images/0007/9046/ssc2011-06c1_Med.jpg" TileLevels="0" WidthFactor="2" Rotation="0.0327671586219935" Projection="SkyImage" FileType=".tif" CenterY="-5.1418572" CenterX="83.8512496" BottomsUp="False" OffsetX="462.282649573171" OffsetY="161.553388241088" BaseTileLevel="0" BaseDegreesPerTile="0.000681332472922861" FOV="0.000681332472922861">
@@ -23,6 +25,7 @@
       </ImageSet>
     </ForegroundImageSet>
   </Place>
+      -->
   <Place MSRCommunityId="0" MSRComponentId="0" Permission="0" Name="Orion Nebula Spitzer" DataSetType="Sky" RA="5.5808333333333344" Dec="-5.44416666666667" Constellation="ORI" Classification="Nebula" Magnitude="0" Distance="0" ZoomLevel="19.59" Rotation="0" Angle="0" DomeAlt="0" DomeAz="0" Opacity="100" AngularSize="19.59">
     <Target>orionnebula</Target>
     <ForegroundImageSet>
@@ -65,51 +68,14 @@
   </Place>
   <Place MSRCommunityId="0" MSRComponentId="0" Permission="0" Name="Crab Nebula : Dead Star Creates Celestial Havoc" DataSetType="Sky" RA="5.5755555555555461" Dec="22.0166666666667" Constellation="TAU" Classification="SupernovaRemnant" Magnitude="0" Distance="0" ZoomLevel="1" Rotation="0" Angle="0" DomeAlt="0" DomeAz="0" Opacity="100" AngularSize="1">
     <Target>Undefined</Target>
-      <div class="What">
-        <h4>What is it?</h4>
-        <ul>
-        <li>The Orion Nebula is a large cloud of gas and dust. You can see the Orion Nebula with the naked eye from a dark sky. It appears as a sword, below the middle star of Orion’s belt. See where the nebula appears in the constellation Orion.</li>
-        <li>A group of hot, young stars embedded in the cloud lights up much of the nebula.  Other parts of the cloud are cold and dense and appear dark.</li>
-        </ul> 
-      </div>
-      <div class="Process">
-        <h4>What is happening?</h4>
-        <ul>
-        <li>The embedded stars illuminate the cloud and give extra energy to the gas, which causes the atoms in the gas to emit light at very specific wavelengths. Astronomers use the emitted light to identify what elements are present in the gas. For example, red light emitted from the cloud tells us there is hydrogen present. Green light indicates oxygen.</li>
-        <li>In the coldest, darkest parts of the cloud, gravity is pulling gas and dust in that region into dense clumps.</li>
-        <li>For the most part, the mix of elements inside the cloud does not change.</li>
-        </ul> 
-      </div>
-      <div class="Properties">
-        <h4>Properties/Characteristics</h4>
-        <ul>
-        <li>Distance from Earth: 1300 light years (1.2 x 10<sup>16</sup> km</li>
-        <li>Size: 24 light years across (2.3 x 10<sup>14</sup> km)</li>
-        <li>Mass: 2000 solar masses (4 x 10<sup>33</sup> kg)</li>
-        <li>Temperature: variable in the cloud, ranges from 10K to 10,000K</li>
-        </ul>
-      </div>
-      <div class="Elements">
-        <h4>Elements present/Composition</h4>
-        <ul>
-        <li>71&#37; Hydrogen</li> 
-        <li>28&#37; Helium</li>
-        <li>Trace amounts of heavier elements, like carbon, nitrogen, oxygen, neon, sulfur, chlorine, argon</li>
-        </ul>
-      </div>
-    </Description>
-  </Place>
-  <Place MSRCommunityId="0" MSRComponentId="0" Permission="0" Name="Crab Nebula : Dead Star Creates Celestial Havoc" DataSetType="Sky" RA="5.5755555555555461" Dec="22.0166666666667" Constellation="TAU" Classification="SupernovaRemnant" Magnitude="0" Distance="0" ZoomLevel="1" Rotation="0" Angle="0" DomeAlt="0" DomeAz="0" Opacity="100" AngularSize="1">
-    <Target>crabnebula</Target>
-    <ForegroundImageSet>
-      <ImageSet DemUrl="" MSRCommunityId="0" MSRComponentId="0" Permission="0" Generic="False" DataSetType="Sky" BandPass="Visible" Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000001102{Q}?g=138" TileLevels="4" WidthFactor="2" Sparse="True" Rotation="-0.0751860195300311" QuadTreeMap="0123" Projection="Tangent" Name="Crab Nebula : Dead Star Creates Celestial Havoc" FileType=".png" CenterY="22.0172769653712" CenterX="83.6331623858263" BottomsUp="False" StockSet="False" ElevationModel="False" OffsetX="0" OffsetY="0" BaseTileLevel="0" BaseDegreesPerTile="0.22681269761397" MeanRadius="0" FOV="0.22681269761397">
+        <ForegroundImageSet>
+      <ImageSet DemUrl="" MSRCommunityId="0" MSRComponentId="0" Permission="0" Generic="False" DataSetType="Sky" BandPass="Visible" Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000001102{Q}?g=138" TileLevels="4" WidthFactor="2" Sparse="True" Rotation="-0.0751860195300311" QuadTreeMap="0123" Projection="Tangent" Name="Crab Nebula : Dead Star Creates Celestial Havoc" FileType=".png" CenterY="22.0172769653712" CenterX="83.6331623858263" BottomsUp="False" StockSet="False" ElevationModel="False" OffsetX="0" OffsetY="0" BaseTileLevel="0" BaseDegreesPerTile="0.22681269761397" MeanRadius="0" FOV="0.2268127">
         <Credits>Credit: NASA, ESA, CXC, JPL-Caltech, J. Hester and A. Loll (Arizona State Univ.), R. Gehrz (Univ. Minn.), and STScI</Credits>
         <CreditsUrl>http://hubblesite.org/newscenter/newsdesk/archive/releases/2005/37/</CreditsUrl>
         <ThumbnailUrl>http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=912623430</ThumbnailUrl>
       </ImageSet>
     </ForegroundImageSet>
     <Description Title="Crab Nebula">
-      <p>Big star went blam!</p>
     </Description>
   </Place>
   <Place MSRCommunityId="0" MSRComponentId="0" Permission="0" Name="Betelgeuse" DataSetType="Sky" RA="5.9194444446666665" Dec="7.406944444" Constellation="ORI" Classification="Star" Magnitude="0.5" Distance="0" ZoomLevel="-1" Rotation="0" Angle="0" DomeAlt="0" DomeAz="0" Opacity="100" AngularSize="-1">
@@ -123,7 +89,7 @@
   <Place MSRCommunityId="0" MSRComponentId="0" Permission="0" Name="The Ring Nebula (M57)" DataSetType="Sky" RA="18.893055555555591" Dec="33.0283333333333" Constellation="LYR" Classification="Nebula" Magnitude="0" Distance="0" ZoomLevel="0.565" Rotation="0" Angle="0" DomeAlt="0" DomeAz="0" Opacity="100" AngularSize="0.565">
     <Target>ringnebula</Target>
     <ForegroundImageSet>
-      <ImageSet DemUrl="" MSRCommunityId="0" MSRComponentId="0" Permission="0" Generic="False" DataSetType="Sky" BandPass="Visible" Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000001201{Q}?g=138" TileLevels="3" WidthFactor="2" Sparse="True" Rotation="33.4150621086519" QuadTreeMap="0123" Projection="Tangent" Name="The Ring Nebula (M57)" FileType=".png" CenterY="33.0294929455291" CenterX="283.395104978147" BottomsUp="False" StockSet="False" ElevationModel="False" OffsetX="0" OffsetY="0" BaseTileLevel="0" BaseDegreesPerTile="0.0565749886281826" MeanRadius="0" FOV="0.0565749886281826">
+        <ImageSet DemUrl="" MSRCommunityId="0" MSRComponentId="0" Permission="0" Generic="False" DataSetType="Sky" BandPass="Visible" Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000001201{Q}?g=138" TileLevels="3" WidthFactor="2" Sparse="True" Rotation="33.4150621086519" QuadTreeMap="0123" Projection="Tangent" Name="The Ring Nebula (M57)" FileType=".png" CenterY="33.0294929455291" CenterX="283.395104978147" BottomsUp="False" StockSet="False" ElevationModel="False" OffsetX="0" OffsetY="0" BaseTileLevel="0" BaseDegreesPerTile="0.0565749886281826" MeanRadius="0" FOV="0.0565749886281826">
         <Credits>Credit: The Hubble Heritage Team (AURA/STScI/NASA)</Credits>
         <CreditsUrl>http://hubblesite.org/newscenter/newsdesk/archive/releases/1999/01/</CreditsUrl>
         <ThumbnailUrl>http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1808329735</ThumbnailUrl>
@@ -238,7 +204,6 @@
     </div>
     </Description>
   </Place>
-
   <Place MSRCommunityId="0" MSRComponentId="0" Permission="0" Name="Orion Constellation" DataSetType="Sky" RA="5.5764999999999993" Dec="-0.33" Constellation="ORI" Classification="Constellation" Magnitude="0" Distance="0" ZoomLevel="-1" Rotation="0" Angle="0" DomeAlt="0" DomeAz="0" Opacity="100" AngularSize="-1">
     <ImageSet FOV="23">
     <Target>orionconstellation</Target>


### PR DESCRIPTION
Something went wrong with my attempt to resolve conflicts in the previous merge and broke the WTML file. Should be fixed now.

HOPS 68 is commented out for now until we can register image correctly.

Note: there are still issues I can't track down.  The "go to Sun" button has stopped working and the Ring Nebula foreground image is no longer displaying.